### PR TITLE
feat: valance control as cover entities (issue #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Valance control.** A motor's valance is now a `cover` entity of its own
+  (*Valance 1* / *Valance 2*) on the same device, with open, close, stop and
+  set-position, alongside the read-only sensors added in 1.6.x. The valance
+  travels in the two settings bytes that the manual command frame already
+  reserved and that this integration previously sent as a fixed `FFFF`; they
+  use the same encoding as a position (percent × 2), with `0xFF` meaning
+  "leave this channel alone". Verified against a Warema awning with a valance
+  (device type 25). (Resolves the remaining part of #4.)
+
+  A valance entity appears only for a channel that has actually reported a
+  position, so hardware without a valance is untouched — no new entities, and
+  every command frame it receives is byte-for-byte what it received before.
+
+  The valance and the cover move independently: a valance command carries the
+  position the cover is already at, and a cover command leaves the valance
+  masked. Verified on hardware that the motor handles the awkward cases
+  itself - it raises a lowered valance before travelling and lowers it again
+  at the destination rather than dragging it, and it accepts a lowered valance
+  at any cover position, including retracted.
+
 ## [1.7.0] - 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 ## ✨ Features
 
 - 🪟 **Full blind control** — Open, close, stop, set position and tilt angle
+- 🎪 **Valance control** — Awning valances as their own cover entities (open, close, stop, position)
 - 💡 **Light control** — WMS dimming actuators as dimmable light entities (brightness + on/off)
 - 📊 **Real-time monitoring** — Position, angle, and motion detection sensors
 - 🌦️ **Weather station support** — Temperature, wind, brightness and rain sensors, auto-discovered from WMS weather-station broadcasts
@@ -182,6 +183,38 @@ Each blind appears as a `cover` entity with:
 > get tilt controls; awnings and roller shutters do not — regardless of which
 > actuator hardware drives them. See *Supported Devices* above for the full
 > product-type table.
+
+### Valance Entities
+
+An awning's valance (the fabric drop at the front) is a second motorised axis
+on the *same* motor as the cover. Each valance channel that reports a position
+appears as its own `cover` entity, *Valance 1* / *Valance 2*, on the cover's
+device:
+
+| Control | Range | Notes |
+|---------|-------|-------|
+| **Position** | 0–100% | 0 = fully lowered, 100 = fully raised |
+| **Open** | — | Raise the valance fully |
+| **Close** | — | Lower the valance fully |
+| **Stop** | — | Stops the motor — including the cover, if it is moving |
+
+> **Auto-detection:** there is no flag that announces a valance. The position
+> frame simply reports `0xFF` for a channel that is not there, so the entity is
+> created the first time a channel reports a real value — within one position
+> poll of startup. Hardware without a valance never gets the entity.
+
+> **Position convention:** the valance is not affected by the per-device
+> *invert position* option. That option describes which end of the *cover's*
+> travel you consider closed; a valance only ever drops downwards, so lowered
+> is always "closed".
+
+> **The two axes move independently.** A valance command carries the position
+> the cover is already at, so only the valance moves, and a cover command
+> leaves the valance untouched. The motor handles the awkward cases itself: it
+> never drags a lowered valance while the cover travels — it raises it, moves,
+> and lowers it again at the destination — and it accepts a lowered valance at
+> any cover position, which is what makes a valance useful at a partial
+> extension when the sun is low.
 
 ### Sensor Entities
 - **Motor SNR** — Serial number (6-digit hex)

--- a/custom_components/warema_wms/coordinator.py
+++ b/custom_components/warema_wms/coordinator.py
@@ -406,6 +406,35 @@ class WaremaCoordinator(DataUpdateCoordinator[dict[int, BlindState]]):
         if self.stick:
             self.stick.blind_set_position(snr, 100, 100)
 
+    def set_valance(
+        self,
+        snr: int,
+        position: int,
+        valance_1: int | None = None,
+        valance_2: int | None = None,
+    ) -> None:
+        """Move a valance, carrying the cover position it belongs to.
+
+        One frame is a single target state covering every axis, so a valance
+        command always states where the cover should be as well. Pass the
+        position the cover is already at to move the valance alone. The slat
+        angle is masked (left untouched).
+
+        Args:
+            snr: Integer serial number of the blind.
+            position: 0-100 WMS cover position sent alongside the valance.
+            valance_1: 0-100 valance position, or None to leave it alone.
+            valance_2: second valance channel, same convention.
+        """
+        if self.stick:
+            self.stick.blind_set_position(
+                snr,
+                position,
+                None,
+                valance_1=valance_1,
+                valance_2=valance_2,
+            )
+
     def set_light_level(self, snr: int, level: int) -> None:
         """Set the brightness of a dimming actuator.
 

--- a/custom_components/warema_wms/cover.py
+++ b/custom_components/warema_wms/cover.py
@@ -60,6 +60,10 @@ async def async_setup_entry(
     coordinator: WaremaCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     entities = []
+    # Metadata of every cover we create, keyed by integer SNR. A valance is not
+    # a device of its own - it belongs to the cover's motor - so its entity
+    # reuses this to attach to the same HA device.
+    cover_meta: dict[int, dict] = {}
 
     # Per-device position inversion, keyed by string SNR (see OPT_INVERT_POSITION).
     invert_map = entry.options.get(OPT_INVERT_POSITION, {})
@@ -95,6 +99,12 @@ async def async_setup_entry(
                         invert=bool(invert_map.get(str(snr_int), False)),
                     )
                 )
+                cover_meta[snr_int] = {
+                    "snr_hex": snr_hex,
+                    "name": name,
+                    "device_type_str": device_type_str,
+                    "product_type": device.get("product_type"),
+                }
     else:
         # No devices configured: scan and add all blinds
         _LOGGER.info("No devices configured, scanning for WMS devices...")
@@ -121,12 +131,68 @@ async def async_setup_entry(
                         invert=bool(invert_map.get(str(snr), False)),
                     )
                 )
+                cover_meta[snr] = {
+                    "snr_hex": snr_hex,
+                    "name": name,
+                    "device_type_str": device_type_str,
+                    "product_type": device.get("product_type"),
+                }
 
     if entities:
         async_add_entities(entities)
         _LOGGER.info("Added %d Warema WMS cover entities", len(entities))
     else:
         _LOGGER.warning("No Warema WMS cover entities found")
+
+    # ------------------------------------------------------------------
+    # Valance entities
+    # ------------------------------------------------------------------
+    # Whether a motor drives a valance cannot be configured or asked for: the
+    # position frame simply reports 0xFF for a channel that is not there, which
+    # the coordinator surfaces as None. So we watch the live data and create the
+    # entity the first time a channel reports a real value.
+    #
+    # Deliberately driven by observed data rather than by device type or by a
+    # flag stored at config time: a motor that was asleep during setup reports
+    # nothing, and a control entity that appears for hardware that has no
+    # valance would let a user command an axis that does not exist.
+    known_valances: set[tuple[int, int]] = set()
+
+    @callback
+    def _discover_valances() -> None:
+        """Add valance entities for channels that have reported a value."""
+        new_entities = []
+        for snr, state in (coordinator.data or {}).items():
+            meta = cover_meta.get(snr)
+            if meta is None:
+                continue
+            for valance_num, value in ((1, state.valance_1), (2, state.valance_2)):
+                if value is None or (snr, valance_num) in known_valances:
+                    continue
+                known_valances.add((snr, valance_num))
+                _LOGGER.info(
+                    "Valance %d detected on SNR=%d (%s), adding control entity",
+                    valance_num,
+                    snr,
+                    meta["snr_hex"],
+                )
+                new_entities.append(
+                    WaremaValanceCover(
+                        coordinator=coordinator,
+                        snr=snr,
+                        snr_hex=meta["snr_hex"],
+                        device_name=meta["name"],
+                        device_type_str=meta["device_type_str"],
+                        product_type=meta["product_type"],
+                        valance_num=valance_num,
+                        entry_id=entry.entry_id,
+                    )
+                )
+        if new_entities:
+            async_add_entities(new_entities)
+
+    entry.async_on_unload(coordinator.async_add_listener(_discover_valances))
+    _discover_valances()
 
 
 def _device_class_for(product_type: int | None) -> CoverDeviceClass:
@@ -561,4 +627,220 @@ class WaremaCover(CoordinatorEntity[WaremaCoordinator], CoverEntity):
             "wms_position": state.position if state else -1,
             "wms_angle": state.angle if state else 0,
             "moving": state.moving if state else False,
+        }
+
+
+class WaremaValanceCover(CoordinatorEntity[WaremaCoordinator], CoverEntity):
+    """A motor's valance, exposed as a cover of its own.
+
+    A valance (Volant) is the fabric drop at the front of an awning. It is a
+    second motorised axis on the *same* motor as the cover, not a device of its
+    own, so this entity attaches to the cover's HA device.
+
+    Position convention: WMS 100 = fully lowered = HA "closed", i.e. the plain
+    mapping. This deliberately ignores OPT_INVERT_POSITION, which describes
+    which end of the *cover's* travel a user considers closed - the valance
+    only ever drops downwards, so there is nothing to invert.
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = CoverDeviceClass.SHADE
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+        | CoverEntityFeature.SET_POSITION
+    )
+
+    def __init__(
+        self,
+        coordinator: WaremaCoordinator,
+        snr: int,
+        snr_hex: str,
+        device_name: str,
+        device_type_str: str,
+        product_type: int | None,
+        valance_num: int,
+        entry_id: str,
+    ) -> None:
+        """Initialize the valance cover entity."""
+        super().__init__(coordinator, context=snr)
+        self._snr = snr
+        self._snr_hex = snr_hex
+        self._device_name = device_name
+        self._device_type_str = device_type_str
+        self._product_type = product_type
+        self._valance_num = valance_num
+        self._entry_id = entry_id
+
+        self._attr_name = f"Valance {valance_num}"
+        self._attr_unique_id = f"{DOMAIN}_{snr_hex}_valance_{valance_num}_cover"
+
+        self._command_is_opening = False
+        self._command_is_closing = False
+
+    def _get_blind_state(self):
+        """Get the current blind state from coordinator data."""
+        if not self.coordinator.data:
+            return None
+        return self.coordinator.data.get(self._snr)
+
+    def _get_valance(self) -> int | None:
+        """Return this channel's WMS valance position, or None if unknown."""
+        state = self._get_blind_state()
+        if not state:
+            return None
+        return state.valance_1 if self._valance_num == 1 else state.valance_2
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info: the same device as the cover it belongs to."""
+        model = self._device_type_str
+        if self._product_type is not None:
+            model = f"{product_type_name(self._product_type)} ({self._device_type_str})"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._snr_hex)},
+            name=self._device_name,
+            manufacturer="Warema",
+            model=model,
+            via_device=(DOMAIN, self._entry_id),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Available while the channel keeps reporting a position."""
+        return super().available and self._get_valance() is not None
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return valance position in HA convention (0=lowered, 100=raised)."""
+        valance = self._get_valance()
+        if valance is None:
+            return None
+        return _wms_pos_to_ha(valance)
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return True when the valance is fully lowered (WMS 100)."""
+        valance = self._get_valance()
+        if valance is None:
+            return None
+        return valance >= 100
+
+    @property
+    def is_opening(self) -> bool:
+        """Return True while a raise command is in progress."""
+        state = self._get_blind_state()
+        return bool(state and state.moving and self._command_is_opening)
+
+    @property
+    def is_closing(self) -> bool:
+        """Return True while a lower command is in progress."""
+        state = self._get_blind_state()
+        return bool(state and state.moving and self._command_is_closing)
+
+    async def _async_send_valance(self, wms_valance: int) -> bool:
+        """Send a valance target together with a cover position.
+
+        The frame is one target state for every axis, so it has to name a
+        cover position. We send the position the cover is already at, which
+        leaves it where it is and moves only the valance.
+
+        No cover position is refused. Verified on an awning (type 25): the
+        motor never drags a lowered valance while the cover travels - it
+        raises the valance, moves, and lowers it again at the destination -
+        and it accepts a lowered valance at any cover position, including
+        fully retracted. Both are the manufacturer's behaviour, not something
+        this integration should second-guess: lowering the valance at a
+        partial extension is a real use case when the sun is low.
+
+        Returns False when the cover position is not known yet: the frame has
+        to state one, and inventing a value would move the cover. Mirrors how
+        the tilt commands handle the same situation.
+        """
+        state = self._get_blind_state()
+        if not state or state.position < 0:
+            _LOGGER.warning(
+                "WaremaValanceCover: SNR=%d: cover position unknown, requesting update",
+                self._snr,
+            )
+            await self.hass.async_add_executor_job(
+                self.coordinator.get_position, self._snr
+            )
+            return False
+        position = state.position
+
+        _LOGGER.debug(
+            "WaremaValanceCover: SNR=%d (%s) valance_%d -> %d (cover pos=%d)",
+            self._snr,
+            self._snr_hex,
+            self._valance_num,
+            wms_valance,
+            position,
+        )
+        kwargs = {f"valance_{self._valance_num}": wms_valance}
+        await self.hass.async_add_executor_job(
+            lambda: self.coordinator.set_valance(self._snr, position, **kwargs)
+        )
+        return True
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Raise the valance fully (WMS 0)."""
+        if not await self._async_send_valance(0):
+            return
+        self._command_is_opening = True
+        self._command_is_closing = False
+        self.async_write_ha_state()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Lower the valance fully (WMS 100)."""
+        if not await self._async_send_valance(100):
+            return
+        self._command_is_opening = False
+        self._command_is_closing = True
+        self.async_write_ha_state()
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Move the valance to a specific position."""
+        ha_pos = kwargs[ATTR_POSITION]
+        current_ha = self.current_cover_position
+        if not await self._async_send_valance(_ha_pos_to_wms(ha_pos)):
+            return
+        if current_ha is not None:
+            self._command_is_opening = ha_pos > current_ha
+            self._command_is_closing = ha_pos < current_ha
+        else:
+            self._command_is_opening = False
+            self._command_is_closing = False
+        self.async_write_ha_state()
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the motor.
+
+        The stop frame addresses the motor, not one axis, so this also stops
+        the cover if it happens to be moving.
+        """
+        _LOGGER.debug("WaremaValanceCover: stop SNR=%d (%s)", self._snr, self._snr_hex)
+        await self.hass.async_add_executor_job(self.coordinator.stop, self._snr)
+        self._command_is_opening = False
+        self._command_is_closing = False
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Clear direction flags once the motor reports it has stopped."""
+        state = self._get_blind_state()
+        if state and not state.moving:
+            self._command_is_opening = False
+            self._command_is_closing = False
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        return {
+            "snr": self._snr,
+            "snr_hex": self._snr_hex,
+            "valance_channel": self._valance_num,
+            "wms_valance": self._get_valance(),
         }

--- a/custom_components/warema_wms/pywarema/protocol.py
+++ b/custom_components/warema_wms/pywarema/protocol.py
@@ -162,6 +162,19 @@ def pos_hex_to_percent(pos_hex: str) -> int:
     return round(int(pos_hex, 16) / 2)
 
 
+def valance_percent_to_hex(valance_percent: int | None) -> str:
+    """Convert a valance percentage to its 2-char hex settings byte.
+
+    A valance uses the same encoding as a position (percent * 2). ``None``
+    means "leave this channel alone" and maps to the 0xFF sentinel the
+    protocol uses for an unset settings byte - the same value the position
+    frame reports back for a channel the device does not have.
+    """
+    if valance_percent is None:
+        return "FF"
+    return pos_percent_to_hex(valance_percent)
+
+
 def angle_percent_to_hex(ang_percent: int) -> str:
     """Convert angle percentage (-100 to +100) to 2-char hex string.
 
@@ -383,6 +396,17 @@ def encode_cmd(cmd: str, snr, params: dict) -> dict:
     elif cmd == "blindMoveToPos":
         pos = params.get("pos", 0)
         ang = params.get("ang", 0)
+        # Valance channels. The manual-command frame carries them in the two
+        # settings bytes after the angle, encoded exactly like a position
+        # (percent * 2). 0xFF is the protocol's "leave unchanged" sentinel and
+        # stays the default, so a caller that does not mention a valance emits
+        # a byte-for-byte identical frame to one that never knew about them.
+        valance_1 = params.get("valance_1")
+        valance_2 = params.get("valance_2")
+        # ``ang=None`` masks the slat angle with the same 0xFF sentinel, so a
+        # valance-only move leaves the slats where they are. Callers that pass
+        # a real angle are unaffected.
+        ang_hex = "FF" if ang is None else angle_percent_to_hex(ang)
         result["expect"]["msg_type"] = "blindMoveToPosResponse"
         result["expect"]["snr"] = snr_hex
         result["cmd"] = (
@@ -391,8 +415,10 @@ def encode_cmd(cmd: str, snr, params: dict) -> dict:
             + "7070"
             + "03"
             + pos_percent_to_hex(pos)
-            + angle_percent_to_hex(ang)
-            + "FFFF}"
+            + ang_hex
+            + valance_percent_to_hex(valance_1)
+            + valance_percent_to_hex(valance_2)
+            + "}"
         )
 
     elif cmd == "lightSetLevel":

--- a/custom_components/warema_wms/pywarema/stick.py
+++ b/custom_components/warema_wms/pywarema/stick.py
@@ -63,6 +63,7 @@ from .protocol import (
     encode_cmd,
     manual_position_from_byte,
     manual_position_to_byte,
+    pos_percent_to_hex,
     product_angle_from_byte,
     product_angle_to_byte,
     product_type_name,
@@ -443,17 +444,31 @@ class WmsStick:
         self,
         blind_id,
         position: int,
-        angle: int,
+        angle: Optional[int],
         on_complete: Optional[Callable] = None,
+        valance_1: Optional[int] = None,
+        valance_2: Optional[int] = None,
     ) -> None:
         """Move a blind to the specified position and angle.
 
         Args:
             blind_id: snr, snr_hex, or name
             position: 0-100 (0=open, 100=closed)
-            angle: -100 to +100 (slat angle)
+            angle: -100 to +100 (slat angle), or None to leave the slats alone
             on_complete: Optional callback(error, msg_sent, msg_rcv) called when
                          the motor acknowledges the command.
+            valance_1: 0-100 valance position, or None to leave it alone.
+            valance_2: second valance channel, same convention.
+
+        A valance is driven by this same command: the frame is one target
+        state covering every axis, which is why the valance arguments extend
+        this method rather than getting a command of their own.
+
+        The motor orders the axes of a frame itself: asked to extend and
+        lower the valance at once it extends first, pauses, then lowers, and
+        it never drags a lowered valance while the cover travels - it raises
+        the valance, moves, and lowers it again at the destination. A lowered
+        valance is accepted at any cover position.
         """
         blind = self._get_blind(blind_id)
         if not blind:
@@ -462,7 +477,21 @@ class WmsStick:
             )
             return
 
-        blind.pos_requested = BlindPosition(pos=position, ang=angle, moving=True)
+        blind.pos_requested = BlindPosition(
+            pos=position,
+            ang=blind.pos_current.ang if angle is None else angle,
+            moving=True,
+            valance_1=(
+                blind.pos_current.valance_1
+                if valance_1 is None
+                else pos_percent_to_hex(valance_1)
+            ),
+            valance_2=(
+                blind.pos_current.valance_2
+                if valance_2 is None
+                else pos_percent_to_hex(valance_2)
+            ),
+        )
 
         def _on_complete(error, msg_sent, msg_rcv):
             # error is "" (empty string) on success, "timeout" on timeout
@@ -471,18 +500,30 @@ class WmsStick:
                 # cannot read the slat angle back (returns 0xFF while raised), so
                 # without this the tilt state would never reflect what we just
                 # commanded and the UI would appear "stuck".
+                # The valance is adopted the same way: it is reported by the
+                # position poll, but only once the motor has finished moving
+                # it, so without this the slider would snap back mid-travel.
                 new_pos = BlindPosition(
                     pos=blind.pos_current.pos,
                     ang=blind.pos_requested.ang,
                     moving=True,
-                    valance_1=blind.pos_current.valance_1,
-                    valance_2=blind.pos_current.valance_2,
+                    valance_1=blind.pos_requested.valance_1,
+                    valance_2=blind.pos_requested.valance_2,
                 )
                 self._update_blind_pos(blind, new_pos)
             if on_complete:
                 on_complete(error, msg_sent, msg_rcv)
 
-        msg = WmsMessage("blindMoveToPos", blind.snr, {"pos": position, "ang": angle})
+        msg = WmsMessage(
+            "blindMoveToPos",
+            blind.snr,
+            {
+                "pos": position,
+                "ang": angle,
+                "valance_1": valance_1,
+                "valance_2": valance_2,
+            },
+        )
         msg.on_end = _on_complete
         self._enqueue(msg, priority=True)
         threading.Timer(DELAY_MSG_PROC, self._process_queue).start()

--- a/tests/test_valance_encoding.py
+++ b/tests/test_valance_encoding.py
@@ -1,0 +1,135 @@
+"""Frame-encoding tests for valance support.
+
+Stdlib only and no Home Assistant import: ``pywarema.protocol`` is pure
+Python, so this runs anywhere with ``python -m unittest discover tests``.
+
+The point of these tests is the backwards-compatibility guarantee. Valance
+support widens an existing frame, so the first test class pins the bytes that
+every pre-existing call site produces. If those ever change, hardware that has
+no valance would start receiving different commands.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "custom_components",
+        "warema_wms",
+    ),
+)
+
+from pywarema.protocol import encode_cmd  # noqa: E402
+
+SNR = 995603
+SNR_HEX = "13310F"
+
+
+def move(**params) -> str:
+    """Encode a blindMoveToPos frame and return the wire string."""
+    return encode_cmd("blindMoveToPos", SNR, params)["cmd"]
+
+
+class TestUnchangedForDevicesWithoutValance(unittest.TestCase):
+    """Every call that predates valance support must emit identical bytes.
+
+    Expected values are the literal output of the previous implementation,
+    which ended each frame with a hardcoded "FFFF".
+    """
+
+    def test_closed_no_tilt(self):
+        self.assertEqual(move(pos=100, ang=0), "{R06" + SNR_HEX + "707003C87FFFFF}")
+
+    def test_open_tilt_out(self):
+        self.assertEqual(move(pos=0, ang=-100), "{R06" + SNR_HEX + "7070030034FFFF}")
+
+    def test_mid_position_tilt_in(self):
+        self.assertEqual(move(pos=50, ang=100), "{R06" + SNR_HEX + "70700364CAFFFF}")
+
+    def test_trailing_bytes_stay_masked_for_every_pos_and_angle(self):
+        # The valance bytes are the last two before the closing brace. Without
+        # valance arguments they must read FFFF for every reachable position
+        # and angle - that is the whole no-regression guarantee.
+        for pos in range(0, 101):
+            for ang in range(-100, 101):
+                frame = move(pos=pos, ang=ang)
+                self.assertEqual(frame[-5:], "FFFF}", f"pos={pos} ang={ang} -> {frame}")
+
+    def test_defaults_are_unchanged(self):
+        # No pos/ang at all: both still default to 0.
+        self.assertEqual(move(), "{R06" + SNR_HEX + "707003007FFFFF}")
+
+    def test_valance_none_is_same_as_absent(self):
+        self.assertEqual(
+            move(pos=100, ang=0, valance_1=None, valance_2=None), move(pos=100, ang=0)
+        )
+
+
+class TestValanceEncoding(unittest.TestCase):
+    """A valance is encoded like a position (percent * 2)."""
+
+    def test_valance_1_lowered(self):
+        self.assertEqual(
+            move(pos=100, ang=None, valance_1=100),
+            "{R06" + SNR_HEX + "707003C8FFC8FF}",
+        )
+
+    def test_valance_1_raised(self):
+        self.assertEqual(
+            move(pos=100, ang=None, valance_1=0),
+            "{R06" + SNR_HEX + "707003C8FF00FF}",
+        )
+
+    def test_valance_1_half(self):
+        self.assertEqual(
+            move(pos=100, ang=None, valance_1=50),
+            "{R06" + SNR_HEX + "707003C8FF64FF}",
+        )
+
+    def test_valance_2_leaves_valance_1_masked(self):
+        self.assertEqual(
+            move(pos=100, ang=None, valance_2=25),
+            "{R06" + SNR_HEX + "707003C8FFFF32}",
+        )
+
+    def test_angle_masked_only_when_explicitly_none(self):
+        # Byte layout after the "7070" command and its "03" flags byte:
+        # position, angle, valance 1, valance 2.
+        with_angle = move(pos=100, ang=0, valance_1=100)
+        self.assertEqual(with_angle[18:20], "7F")  # ang=0 is a real angle
+        without_angle = move(pos=100, ang=None, valance_1=100)
+        self.assertEqual(without_angle[18:20], "FF")  # masked
+
+    def test_valance_is_clamped_like_a_position(self):
+        self.assertEqual(
+            move(pos=0, ang=None, valance_1=150), move(pos=0, ang=None, valance_1=100)
+        )
+        self.assertEqual(
+            move(pos=0, ang=None, valance_1=-10), move(pos=0, ang=None, valance_1=0)
+        )
+
+
+class TestAgainstKnownWorkingImplementation(unittest.TestCase):
+    """Match frames from an independent implementation, verified on hardware.
+
+    These are the exact bytes produced by a long-running Node.js bridge driving
+    a Warema awning with a valance (device type 25, SNR 995603) in daily use
+    since 2024. It masks the slat angle and writes valance 1 only.
+    """
+
+    def test_lower_valance_on_extended_awning(self):
+        self.assertEqual(
+            move(pos=100, ang=None, valance_1=100), "{R0613310F707003C8FFC8FF}"
+        )
+
+    def test_raise_valance_on_extended_awning(self):
+        self.assertEqual(
+            move(pos=100, ang=None, valance_1=0), "{R0613310F707003C8FF00FF}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is the pull request in reference to issue #4. I ended up having Claude Code (Opus) implement it and I tested everything successfully on my hardware.

In my opinion noteworthy for review:
- The PR does not touch the read-only sensor that was implemented for #4. You might want to remove it.
- The valance entity becomes available when there is a first reading with valance status. This is deliberately more conservative than assuming that the device type is always right. In my tests the valance control popped up as soon as I touched the awning control for the first time.
- Of course Claude is quite eager as these systems are. The PR contains documentation, code comments, tests and everything. Feel free to just take the entire thing, edit out what you don't like, cherry pick parts of it or just reject the entire PR and take just the info for your own implementation. I have no personal attachment to the code - after all I didn't write it myself :)

Here is the sumary from Claude:

---

A motor's valance becomes a cover entity of its own ("Valance 1" / "Valance 2") on the same device, with open, close, stop and set position, alongside the read-only sensors from 1.6.x.

Protocol: the valance travels in the two settings bytes that the blindMoveToPos frame already reserved and that we sent as a fixed FFFF. They use the position encoding (percent * 2); 0xFF stays the "leave this channel alone" sentinel. The angle byte gains the same masking so a valance move leaves the slats alone.

Backwards compatibility: the valance parameters default to None, which renders as FF, so every pre-existing call site emits a byte-identical frame. Verified exhaustively against the previous implementation over all 20301 reachable position/angle combinations, plus blindGetPos, lightSetLevel and blindStopMove. tests/test_valance_encoding.py pins this.

Discovery is driven by observed data rather than device or product type: the position frame reports 0xFF for a channel that is not there, so the entity appears the first time a channel reports a real value. Hardware without a valance gets no new entity.

The two axes move independently. Verified on hardware that the motor raises a lowered valance before travelling and restores it at the destination rather than dragging it, and that it accepts a lowered valance at any cover position - so forcing full extension was considered and rejected, as it would remove a supported capability.

Tested on an awning with one valance (device type 25, product type 6 AwningOneValanceOneOrTwoWindsensors) with Home Assistant 2026.8.3.
