### PR TITLE
Fix discovery from an idle WMS queue and unblock cover setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+- **Device discovery can now start from an idle command queue.** Starting a
+  network scan enqueued its three scan requests but did not wake the USB-stick
+  queue processor. If no other WMS command followed, Home Assistant waited for
+  the scan timeout and reported no devices even though they were reachable.
+- **Cover setup is no longer blocked by optional motor diagnostics.** Reading
+  firmware parameters requires several serial requests per motor. These reads
+  now continue in the background after the covers are available, avoiding long
+  startup delays when a receiver is slow or temporarily unreachable.
+
 ## [1.8.0] - 2026-08-26
 
 ### Added

--- a/custom_components/warema_wms/coordinator.py
+++ b/custom_components/warema_wms/coordinator.py
@@ -199,7 +199,16 @@ class WaremaCoordinator(DataUpdateCoordinator[dict[int, BlindState]]):
         # still lack info, so steady-state startup cost is zero. The result is
         # persisted back to entry.data so the lookup never repeats.
         await self._enrich_product_info()
-        await self.async_refresh_motor_params()
+
+        # Motor parameter reads are diagnostics, not a prerequisite for cover
+        # setup. Each motor requires several serial requests, so waiting here
+        # can delay setup for tens of seconds when a receiver is unreachable.
+        # Run the refresh independently and notify the diagnostic entities once
+        # it has data.
+        self.hass.async_create_background_task(
+            self.async_refresh_motor_params(),
+            f"{DOMAIN} motor parameter refresh",
+        )
 
     async def _enrich_product_info(self) -> None:
         """Fill in missing product_type / is_with_blinds for blinds.

--- a/custom_components/warema_wms/pywarema/stick.py
+++ b/custom_components/warema_wms/pywarema/stick.py
@@ -334,6 +334,10 @@ class WmsStick:
         msg = WmsMessage("scanRequest", 0, {"pan_id": self.pan_id})
         msg.on_end = finish_scan
         self._enqueue(msg)
+        # A scan is normally started after the command queue has gone idle.
+        # Wake it explicitly; otherwise the scan requests remain queued until
+        # another command happens to restart queue processing.
+        threading.Timer(DELAY_MSG_PROC, self._process_queue).start()
 
     def blind_add(self, snr, name: str) -> Blind:
         """Add a blind to the stick's device list.

--- a/tests/test_scan_queue.py
+++ b/tests/test_scan_queue.py
@@ -1,0 +1,74 @@
+"""Tests for starting a WMS network scan from an idle command queue.
+
+The production integration supplies pyserial through Home Assistant.  Stub it
+here so this focused queue test stays runnable with the Python standard library
+alone, like the other protocol tests in this directory.
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+sys.modules.setdefault("serial", types.SimpleNamespace(Serial=object))
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "custom_components",
+        "warema_wms",
+    ),
+)
+
+from pywarema.stick import DELAY_MSG_PROC, WmsStick  # noqa: E402
+
+
+class TimerSpy:
+    """Record timers without starting background threads in a unit test."""
+
+    instances = []
+
+    def __init__(self, delay, callback):
+        self.delay = delay
+        self.callback = callback
+        self.started = False
+        self.__class__.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+
+class TestScanQueue(unittest.TestCase):
+    """A scan must wake queue processing when no other command is running."""
+
+    def setUp(self):
+        TimerSpy.instances.clear()
+        self.stick = WmsStick(
+            port="/dev/null",
+            channel=17,
+            pan_id="ABCD",
+            key="0123456789ABCDEF0123456789ABCDEF",
+            callback=lambda *_: None,
+            auto_open=False,
+        )
+
+    def test_scan_starts_queue_processor(self):
+        with patch("pywarema.stick.threading.Timer", TimerSpy):
+            self.stick.scan_devices()
+
+        self.assertEqual(
+            [message.cmd for message in self.stick._msg_queue],
+            ["scanRequest", "scanRequest", "scanRequest"],
+        )
+        self.assertEqual(len(TimerSpy.instances), 1)
+        timer = TimerSpy.instances[0]
+        self.assertEqual(timer.delay, DELAY_MSG_PROC)
+        self.assertTrue(timer.started)
+        self.assertEqual(timer.callback.__self__, self.stick)
+        self.assertEqual(timer.callback.__func__, self.stick._process_queue.__func__)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This fixes two queue/startup issues observed with a WMS USB Stick and multiple WMS radio motors.

1. **Network discovery from an idle queue**
   `scan_devices()` enqueues three `scanRequest` messages, but did not schedule the queue processor. When the command queue was already idle, the requests could remain queued until an unrelated command restarted processing. Home Assistant then reached its scan timeout and reported that no new devices were found, even though the receivers were reachable.

   The scan now explicitly schedules `_process_queue()`, consistent with other command entry points.

2. **Cover setup blocked by optional motor diagnostics**
   `async_connect()` awaited a full motor-parameter refresh before the integration finished setting up. This refresh performs several serial requests per motor. A slow or temporarily unreachable receiver can therefore delay the entire cover setup for tens of seconds, even though cover control does not depend on those diagnostic values.

   The diagnostic refresh now runs as a Home Assistant background task. Diagnostic entities are updated when the refresh completes; covers become available without waiting.

Neither change alters WMS command frames or motor-control behaviour.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Related Issues
None.

## Testing
- [x] Manual testing with a Warema WMS USB Stick and multiple WMS radio motors/screens
  - Reproduced the scan timeout after invoking discovery while the queue was idle.
  - Confirmed the installation could subsequently discover all configured receivers.
  - Observed motor-parameter read timeouts delaying setup for unreachable or weakly reachable receivers.
- [x] `python -m unittest discover tests -v` — 15 tests passed
- [x] `black --check custom_components/warema_wms tests`
- [x] JSON validation for `manifest.json` and `strings.json`

## Checklist
- [x] Code follows the style guidelines (Black formatted)
- [x] I have updated the CHANGELOG.md
- [x] I have added/updated comments for complex logic
- [x] I have tested locally with Home Assistant hardware
- [x] No new warnings are generated
- [x] Dependencies have not been unnecessarily added

## Hardware Tested
- Device Types: WMS radio motors/screens
- Integration version during reproduction: v1.7.0
